### PR TITLE
add Stash for iOS

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -29,10 +29,14 @@ QX暂时需要通过backend方式使用，添加如下配置。注意，HTTP bac
 https://raw.githubusercontent.com/Peng-YM/Sub-Store/master/backend/sub-store.js, tag=Sub-Store, path=/, enabled=true
 ```
 
+## 4. Stash
+推荐直接使用[覆写](https://raw.githubusercontent.com/Peng-YM/Sub-Store/master/config/Stash.stoverride)。
+
+
 ## 界面配置：
 
-### 1. Loon & Surge
-Loon和Surge用户，打开这个[页面](https://sub-store.vercel.app/)即可。
+### 1. Loon, Surge & Stash
+Loon,Surge和Stash用户，打开这个[页面](https://sub-store.vercel.app/)即可。
 
 ### 2. QX
 QX用户需要曲线救国，使用[JSBox版本]()。

--- a/config/Stash.stoverride
+++ b/config/Stash.stoverride
@@ -1,0 +1,16 @@
+name: Sub-Store
+desc: 高级订阅管理工具 @Peng-YM
+
+http:
+  mitm:
+    - sub.store
+  script:
+    - match: ^https?:\/\/sub\.store
+      name: sub-store
+      type: request
+      require-body: true
+      timeout: 120
+script-providers:
+  sub-store:
+    url: https://raw.githubusercontent.com/Peng-YM/Sub-Store/master/backend/sub-store.min.js
+    interval: 86400


### PR DESCRIPTION
Sub-Store 增加 Stash for iOS 支持；

Stash 是一款 iOS 平台基于规则的多协议代理客户端，完全兼容 Clash Premium 配置，支持 Rule Set 规则、JavaScript 脚本、HTTP 改写、MitM、SSID Policy Group、按需连接等新特性。

App Store 链接：https://apps.apple.com/app/stash/id1596063349

我们已在最新的 1.5.0 测试版 (Build 199) 完整支持了 JavaScript 脚本，并且测试 Sub-Store 使用正常。烦请作者接受我们的 PR 和欢迎与我们联系免费获取最新的 TestFlight 测试版，联系方式 dev@stash.ws / Telegram: @viannalau 

祝好，
Stash