### PR TITLE
fix: 使用 URLSearchParams 正确解析脚本链接参数

### DIFF
--- a/backend/src/core/proxy-utils/index.js
+++ b/backend/src/core/proxy-utils/index.js
@@ -125,14 +125,11 @@ async function processFn(
                         // 支持 `#${encodeURIComponent(JSON.stringify({arg1: "1"}))}`
                         $arguments = JSON.parse(decodeURIComponent(rawArgs[1]));
                     } catch (e) {
-                        for (const pair of rawArgs[1].split('&')) {
-                            const key = pair.split('=')[0];
-                            const value = pair.split('=')[1];
-                            // 部分兼容之前的逻辑 const value = pair.split('=')[1] || true;
-                            $arguments[key] =
-                                value == null || value === ''
-                                    ? true
-                                    : decodeURIComponent(value);
+                        // 使用 URLSearchParams 正确解析参数
+                        // 解决 `key=value&key2=value2` 中 value 包含 `,` 或 `=` 的问题
+                        const params = new URLSearchParams(rawArgs[1]);
+                        for (const [key, value] of params) {
+                            $arguments[key] = value == null || value === '' ? true : decodeURIComponent(value);
                         }
                     }
                 }


### PR DESCRIPTION
解决 `key=value&key2=value2` 格式参数中 value 包含 `,` 或 `=` 时解析错误的问题

例如 `sort=region_code(HK,SG,JP,US) ASC, tag(IPLC) DESC` 中的逗号会导致解析失败