### PR TITLE
feat: add proxy utils esm bundle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,7 @@ jobs:
             ./backend/dist/sub-store-1.min.js
             ./backend/dist/sub-store-parser.loon.min.js
             ./backend/dist/cron-sync-artifacts.min.js
+            ./backend/dist/proxy-utils.esm.mjs
             ./backend/dist/sub-store.bundle.js
       - name: Git push assets to "release" branch
         run: |

--- a/backend/bundle-esbuild.js
+++ b/backend/bundle-esbuild.js
@@ -34,6 +34,25 @@ const { build } = require('esbuild');
         });
     }
 
+    const browserEsmArtifacts = [
+        {
+            src: 'src/products/proxy-utils.esm.js',
+            dest: 'dist/proxy-utils.esm.mjs',
+        },
+    ];
+
+    for await (const artifact of browserEsmArtifacts) {
+        await build({
+            entryPoints: [artifact.src],
+            bundle: true,
+            minify: true,
+            sourcemap: false,
+            platform: 'browser',
+            format: 'esm',
+            outfile: artifact.dest,
+        });
+    }
+
     let content = fs.readFileSync(path.join(__dirname, 'sub-store.min.js'), {
         encoding: 'utf8',
     });

--- a/backend/src/products/proxy-utils.esm.js
+++ b/backend/src/products/proxy-utils.esm.js
@@ -1,0 +1,5 @@
+import { ProxyUtils } from '@/core/proxy-utils';
+
+const { parse, produce } = ProxyUtils;
+
+export { parse, produce };


### PR DESCRIPTION
新增一个面向浏览器原生 ESM 的节点转换打包产物：dist/proxy-utils.esm.mjs。

该产物只暴露 parse 和 produce，方便插件或浏览器环境直接复用 Sub-Store 的节点解析与生成能力，无需嵌入或手动同步大段转换代码，也不需要引入完整后端运行入口。

同时更新发布工作流，将该产物加入 Release 附件，方便下游直接引用。