### PR TITLE
feat(SurgeMac): expose mihomoMerge / mihomoMergeName via URL query

### DIFF
--- a/backend/src/restful/download.js
+++ b/backend/src/restful/download.js
@@ -99,6 +99,16 @@ async function downloadSubscription(req, res) {
     let { name, nezhaIndex } = req.params;
 
     const useMihomoExternal = req.query.target === 'SurgeMac';
+    // 仅在 useMihomoExternal=true 时生效：让全部节点共用一个 mihomo 进程 + 多个 SOCKS5 listener
+    // 等价于在脚本里对每个节点设置 _merge=true，避免每个节点 spawn 一个 mihomo 进程
+    const mihomoMerge =
+        useMihomoExternal &&
+        ['true', '1', ''].includes(String(req.query.mihomoMerge ?? ''));
+    const mihomoMergeName =
+        typeof req.query.mihomoMergeName === 'string' &&
+        req.query.mihomoMergeName.length > 0
+            ? req.query.mihomoMergeName
+            : undefined;
 
     const platform =
         req.query.platform ||
@@ -109,6 +119,13 @@ async function downloadSubscription(req, res) {
     $.info(
         `正在下载订阅：${name}\n请求 User-Agent: ${reqUA}\n请求 target: ${req.query.target}\n实际输出: ${platform}`,
     );
+    if (mihomoMerge) {
+        $.info(
+            `已启用 mihomoMerge：合并所有 Mihomo External 节点到单个进程${
+                mihomoMergeName ? `（名称：${mihomoMergeName}）` : ''
+            }`,
+        );
+    }
     let {
         url,
         ua,
@@ -225,6 +242,8 @@ async function downloadSubscription(req, res) {
                 produceOpts: {
                     'include-unsupported-proxy': includeUnsupportedProxy,
                     useMihomoExternal,
+                    merge: mihomoMerge,
+                    mergeName: mihomoMergeName,
                     prettyYaml,
                 },
                 $options,
@@ -419,6 +438,16 @@ async function downloadCollection(req, res) {
     let { name, nezhaIndex } = req.params;
 
     const useMihomoExternal = req.query.target === 'SurgeMac';
+    // 仅在 useMihomoExternal=true 时生效：让全部节点共用一个 mihomo 进程 + 多个 SOCKS5 listener
+    // 等价于在脚本里对每个节点设置 _merge=true，避免每个节点 spawn 一个 mihomo 进程
+    const mihomoMerge =
+        useMihomoExternal &&
+        ['true', '1', ''].includes(String(req.query.mihomoMerge ?? ''));
+    const mihomoMergeName =
+        typeof req.query.mihomoMergeName === 'string' &&
+        req.query.mihomoMergeName.length > 0
+            ? req.query.mihomoMergeName
+            : undefined;
 
     const platform =
         req.query.platform ||
@@ -432,6 +461,13 @@ async function downloadCollection(req, res) {
     $.info(
         `正在下载组合订阅：${name}\n请求 User-Agent: ${reqUA}\n请求 target: ${req.query.target}\n实际输出: ${platform}`,
     );
+    if (mihomoMerge) {
+        $.info(
+            `已启用 mihomoMerge：合并所有 Mihomo External 节点到单个进程${
+                mihomoMergeName ? `（名称：${mihomoMergeName}）` : ''
+            }`,
+        );
+    }
 
     let {
         ignoreFailedRemoteSub,
@@ -510,6 +546,8 @@ async function downloadCollection(req, res) {
                 produceOpts: {
                     'include-unsupported-proxy': includeUnsupportedProxy,
                     useMihomoExternal,
+                    merge: mihomoMerge,
+                    mergeName: mihomoMergeName,
                     prettyYaml,
                 },
                 $options,


### PR DESCRIPTION
## Motivation

`producers/surgemac.js` already implements a **merge mode** ([surgemac.js#L119-L160](https://github.com/sub-store-org/Sub-Store/blob/master/backend/src/core/proxy-utils/producers/surgemac.js#L119)) that emits:

- N × `socks5,127.0.0.1:<port>` Surge proxy entries (one per node), and
- 1 × shared `external,exec=mihomo,args=-config <merged-config>` entry with N inbound SOCKS5 listeners and N internal `proxies[]`

This is exactly the right shape when a subscription contains many nodes whose protocol Surge does not natively support (e.g. VLESS-Reality with `xtls-rprx-vision`) — Surge needs only **one** mihomo subprocess, regardless of node count.

However, the only way to enable it today is to add a JS script operator that sets `_merge = true` on every proxy (documented as comment #24 in `scripts/demo.js`). Many users don't know this exists.

### Real-world impact observed

On a CERNET / 校园网 with native IPv6, where most overseas VPS IPs are reachable only intermittently:

- Subscription with ~53 VLESS-Reality nodes → Surge spawned **53 separate mihomo processes**
- Each process attempted its own outbound TCP to `*.inetsnode.de:<port>`
- Surge's enhanced mode intercepted those outbound flows and routed them through the `External Bypass` rule → DIRECT
- DIRECT TCP from CERNET to overseas VPS IPs timed out at ~8s each
- 53 simultaneous failing connections (plus 53 separate DoH lookups against `doh.pub`) saturated the outbound SYN queue and Surge's flow-tracking path
- Unrelated foreground traffic (qidian, xiaohongshu, etc.) became visibly laggy

Confirmed via `surge-cli --raw dump active` + `dump recent`: every slow connection had `processPath=mihomo` and `rule=External Bypass`. Killing all mihomo processes immediately restored normal performance.

The merge mode would have eliminated this entirely (1 process instead of 53), but requires the user to either:

1. Write a custom script operator (high friction), or
2. Manually edit per-proxy `_merge` fields after the producer runs (loses on next sync)

## What this PR does

Adds two URL query parameters that flow through to `produceOpts`:

| Param | Type | Behavior |
|---|---|---|
| `mihomoMerge` | `'true' \| '1' \| ''` | Enables shared-mihomo merge mode (only when `target=SurgeMac`) |
| `mihomoMergeName` | string | Optional name override for the merged external entry (defaults to `mihomo merged`) |

The producer code already reads `opts.merge` and `opts.mergeName`, so this PR is purely plumbing.

### Diff scope

- `backend/src/restful/download.js` — both `downloadSubscription` and `downloadCollection`: parse query params + pass into `produceOpts`. Two log lines when enabled. ~38 added lines, no removals.
- No producer / core changes.
- No behavior change when `mihomoMerge` is absent — default unchanged.

### Usage

```
GET /download/<name>?target=SurgeMac&mihomoMerge=true
GET /download/<name>?target=SurgeMac&mihomoMerge=true&mihomoMergeName=Ients-merged
```

### Tests / verification

- `node --check backend/src/restful/download.js` passes
- Manually traced the option from query → `produceOpts` → `ProxyUtils.produce(...)` → `surgemac.js` `produce(proxy, type, opts)` → `const merge = opts?.merge || proxy._merge` → existing merge branch
- `target` other than `SurgeMac` short-circuits to `false`, so this can't affect Surge / Clash / sing-box / Loon / etc. outputs

## Follow-ups (not in this PR)

- Could also expose `mihomoMerge` on the Artifact entity for `cron-sync-artifacts.js`, but that's a UI/data-model change and worth a separate discussion.
- Doc update to `scripts/demo.js` comment #24 mentioning the URL-param form — happy to add in this PR if preferred.